### PR TITLE
Add tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,43 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Build Docker images
+      - id: buildx
+        uses: docker/setup-buildx-action@v3
+      - uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ github.ref }}-${{ github.sha }}
+          restore-keys: |
+            ${{ github.ref }}
+      - uses: docker/build-push-action@v5
+        with:
+          push: false
+          file: Dockerfile
+          builder: ${{ steps.buildx.outputs.name }}
+          tags: purpleblueslime/a:latest
+          load: true
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+
+      # Run tests in Docker Container
+      - run: docker run --rm -v "$(pwd)":/workspaces/a purpleblueslime/a ./test
+
+      # Hack: shrink cache size
+      # https://github.com/docker/build-push-action/issues/252#issuecomment-871700519
+      - if: always()
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,87 @@
+# build rchef for chef
+FROM rust:1.72.0 AS chef
+ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL sparse
+WORKDIR /chef
+ADD https://github.com/booleancoercion/rchef/archive/refs/heads/main.tar.gz main.tar.gz
+RUN tar -xvf main.tar.gz
+WORKDIR /chef/rchef-main
+RUN cargo build -r && ./target/release/rchef --version
+
+# download zig
+FROM ubuntu:23.10 AS zig
+ARG ZIG_VERSION=0.11.0
+RUN apt-get update && apt-get -qq install -y --no-install-recommends xz-utils
+WORKDIR /zig
+ADD https://ziglang.org/download/${ZIG_VERSION}/zig-linux-x86_64-${ZIG_VERSION}.tar.xz /tmp
+RUN tar -xvf /tmp/zig-linux-x86_64-${ZIG_VERSION}.tar.xz
+RUN mv zig-linux-x86_64-${ZIG_VERSION}/ zig
+
+FROM ubuntu:23.10
+ENV DEBIAN_FRONTEND noninteractive
+RUN rm /etc/dpkg/dpkg.cfg.d/excludes
+
+# bats for testing
+COPY --from=bats/bats /opt/bats/ /opt/bats/
+RUN ln -s /opt/bats/bin/bats /usr/local/bin/
+
+# chef
+COPY --from=chef /chef/rchef-main/target/release/rchef /usr/bin
+
+# zig
+COPY --from=zig /zig/zig /opt/zig/
+RUN ln -s /opt/zig/zig /usr/local/bin/
+
+# apt
+RUN <<EOS
+cat > /etc/apt/apt.conf.d/01norecommend <<'EOF'
+APT::Install-Recommends "0";
+APT::Install-Suggests "0";
+EOF
+
+apt-get update
+# git for `spago install`
+apt-get -qq install -y git
+# bc
+apt-get -qq install -y bc
+# brainfuck
+apt-get -qq install -y beef
+# c
+apt-get -qq install -y gcc
+# c++
+apt-get -qq install -y g++
+# dc
+apt-get -qq install -y dc
+# elixir
+apt-get -qq install -y elixir
+# go
+apt-get -qq install -y golang
+# haskell
+apt-get -qq install -y ghc
+# js
+apt-get -qq install -y nodejs npm
+# nim
+apt-get -qq install -y nim
+# python
+apt-get -qq install -y python3 python3-pip
+# r
+apt-get -qq install -y r-base
+# ruby
+apt-get -qq install -y ruby
+# rust
+apt-get -qq install -y rustc
+apt-get clean
+rm -rf /var/lib/apt/lists/*
+EOS
+
+# malbolge
+ADD https://raw.githubusercontent.com/bipinu/malbolge/master/malbolge.c malbolge.c
+RUN gcc malbolge.c && mv a.out /usr/local/bin/malbolge && rm malbolge.c
+
+# nadesiko, purescript
+RUN npm install -g nadesiko3core purescript spago
+
+# whitespace
+RUN mkdir -p ~/.pip && printf '[global]\nbreak-system-packages = true\n'  > ~/.pip/pip.conf && pip install whitespace
+
+WORKDIR /workspaces/a
+CMD ["/usr/bin/env", "bash"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
-<img src='https://user-images.githubusercontent.com/84064124/169527654-0f8a2297-eca4-481b-917e-7bcd2ec0498c.gif'>
-<b><a href='https://github.com/purpleblueslime/a/issues/1'>Wanna contribute?</a></b>
+![Gawr Gura pog gif](
+  <https://user-images.githubusercontent.com/84064124/169527654-0f8a2297-eca4-481b-917e-7bcd2ec0498c.gif>
+)
+
+[![Test](
+  <https://github.com/purpleblueslime/a/actions/workflows/test.yaml/badge.svg>
+)](
+  <https://github.com/purpleblueslime/a/actions/workflows/test.yaml>
+)
+
+[**Wanna contribute?**](https://github.com/purpleblueslime/a/issues/1)

--- a/chef/main.chef
+++ b/chef/main.chef
@@ -11,3 +11,4 @@ Liquefy contents of the mixing bowl.
 Pour contents of the mixing bowl into the baking dish.
 
 Serves 1.
+

--- a/test
+++ b/test
@@ -1,0 +1,132 @@
+#!/usr/bin/env bats
+
+# Usage:
+# Build environment for test (should be run every time you edit the Dockerfile)
+# $ docker build -t purpleblueslime/a .
+#
+# Run bash interpreter inside of built container
+# $ docker run --rm -v "$(pwd)":/workspaces/a -it purpleblueslime/a bash
+#
+# Run tests
+# $ docker run --rm -v "$(pwd)":/workspaces/a purpleblueslime/a ./test
+
+@test "bc" {
+  run bc < bc/a.bc
+  [ "$output" = 'a' ]
+}
+
+@test "brainfuck" {
+  run beef brainfuck/main.bf
+  [ "$output" = 'a' ]
+}
+
+@test "c" {
+  gcc c/main.c
+  run ./a.out
+  rm ./a.out
+  [ "$output" = 'a' ]
+}
+
+@test "chef" {
+  run rchef chef/main.chef
+  [ "$output" = 'a' ]
+}
+
+@test "c++" {
+  g++ cpp/main.cpp
+  run ./a.out
+  rm ./a.out
+  [ "$output" = 'a' ]
+}
+
+@test "dc" {
+  run dc -f dc/a.dc
+  [ "$output" = 'a' ]
+}
+
+@test "elixir" {
+  run elixir elixir/a.exs
+  [ "$output" = 'a' ]
+}
+
+@test "go" {
+  go build go/main.go
+  run ./main
+  [ "$output" = 'a' ]
+}
+
+@test "haskell" {
+  run runghc haskell/main.hs
+  [ "$output" = 'a' ]
+}
+
+@test "js" {
+  run node js/main.js
+  [ "$output" = 'a' ]
+}
+
+@test "malbolge" {
+  run malbolge malbolge/a.mal
+  [ "$output" = 'a' ]
+}
+
+@test "nadesiko" {
+  run snako nadesiko/a.nako
+  [ "$output" = 'a' ]
+}
+
+@test "nim" {
+  nim compile nim/a.nim
+  run ./nim/a
+  rm ./nim/a
+  [ "$output" = 'a' ]
+}
+
+@test "purescript" {
+  cd purescript
+  spago init --force
+  spago install
+  run spago script main.purs
+  rm -rf .gitignore packages.dhall spago.dhall .purs-repl .spago src test
+  cd ..
+  [ "${lines[-1]}" = 'a' ]
+}
+
+@test "python" {
+  run python3 python/main.py
+  [ "$output" = 'a' ]
+}
+
+@test "r" {
+  run Rscript r/a.r
+  [ "$output" = '[1] "a"' ]
+}
+
+@test "ruby" {
+  run ruby ruby/main.rb
+  [ "$output" = 'a' ]
+}
+
+@test "rust" {
+  rustc rust/main.rs
+  run ./main
+  rm ./main
+  [ "$output" = 'a' ]
+}
+
+@test "shell" {
+  run bash ./shell/main.sh
+  [ "$output" = 'a' ]
+}
+
+@test "whitespace" {
+  run whitespace whitespace/a.ws
+  [ "$output" = 'a' ]
+}
+
+@test "zig" {
+  zig build-exe zig/a.zig
+  run ./a
+  rm ./a ./a.o
+  [ "$output" = 'a' ]
+}


### PR DESCRIPTION
This PR adds the test CI workflow and the test script with [bats](https://bats-core.readthedocs.io/en/stable/). It could be useful to maintain this project.

If you do not wish to add a test, please feel free to close this PR,

---

https://github.com/eggplants/a-/actions/runs/6780996328

[![Test](https://github.com/eggplants/a-/actions/workflows/test.yaml/badge.svg)](https://github.com/eggplants/a-/actions/workflows/test.yaml)

```shellsession
$ docker build -t purpleblueslime/a .
...

$ docker run --rm -v "$(pwd)":/workspaces/a -it purpleblueslime/a bash
root@1b85a79e8e4a:/workspaces/a# ./test
 ✓ bc
 ✓ brainfuck
 ✓ c
 ✓ chef
 ✓ c++
 ✓ dc
 ✓ elixir
 ✓ go
 ✓ haskell
 ✓ js
 ✓ malbolge
 ✓ nadesiko
 ✓ nim
 ✓ purescript
 ✓ python
 ✓ r
 ✓ ruby
 ✓ rust
 ✓ shell
 ✓ whitespace
 ✓ zig

21 tests, 0 failures
root@f1a64c7e50f9:/workspaces/a# rchef chef/main.chef
a
root@1b85a79e8e4a:/workspaces/a# exit

$ docker run --rm -v "$(pwd)":/workspaces/a purpleblueslime/a ./test
1..21
ok 1 bc
ok 2 brainfuck
ok 3 c
ok 4 chef
ok 5 c++
ok 6 dc
ok 7 elixir
ok 8 go
ok 9 haskell
ok 10 js
ok 11 malbolge
ok 12 nadesiko
ok 13 nim
ok 14 purescript
ok 15 python
ok 16 r
ok 17 ruby
ok 18 rust
ok 19 shell
ok 20 whitespace
ok 21 zig

$ echo $?
0  # successful
```